### PR TITLE
adds support for Windows

### DIFF
--- a/pexpect_serial/serial_spawn.py
+++ b/pexpect_serial/serial_spawn.py
@@ -21,7 +21,13 @@ PEXPECT LICENSE
 
 """
 
-from pexpect import spawn
+# pexpect.spawn is not supported on some systems (i.e. Windows(TM))
+# See https://pexpect.readthedocs.io/en/stable/overview.html#pexpect-on-windows for details.
+import os
+if os.name in ['nt']:
+    from pexpect.fdpexpect import fdspawn as spawn
+else:
+    from pexpect import spawn
 from pexpect.exceptions import ExceptionPexpect
 
 __all__ = ['SerialSpawn']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyserial
-pexpect
+pexpect>=4


### PR DESCRIPTION
According to upstream documentation[0] Windows(TM) is not supported automatically.
But one can use a drop-in replacement for `pexpect.spawn` in the case of fd based approaches.